### PR TITLE
Add method to automatically add episodes based on torrent item

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,7 @@ test: $(SOURCES) $(TESTS)
 .PHONY: run-debug
 run-debug: $(DEBUG_BIN)
 	$(DEBUG_BIN) ~/.config/trss-test/server.yaml ~/.config/trss-test/feeds.yaml
+
+.PHONY: run
+run: $(RELEASE_BIN)
+	$(RELEASE_BIN) ~/.config/trss-test/server.yaml ~/.config/trss-test/feeds.yaml

--- a/Sources/TorrentRSS/Channel.swift
+++ b/Sources/TorrentRSS/Channel.swift
@@ -154,9 +154,9 @@ struct Series: Codable, TableRecord, FetchableRecord, PersistableRecord {
 }
 
 struct Episode: Codable, TableRecord, FetchableRecord, PersistableRecord {
-    var id: Int?
+    var id: Int64?
     var seriesId: Int
-    var torrentItemId: Int
+    var torrentItemId: Int64
     var episode: Int
     var watchStatus: WatchStatus
 }
@@ -165,4 +165,8 @@ enum WatchStatus: String, Codable {
     case pending
     case ignored
     case watched
+}
+
+enum TRSSError: Error {
+    case noId
 }

--- a/Sources/TorrentRSS/Migrations.swift
+++ b/Sources/TorrentRSS/Migrations.swift
@@ -24,7 +24,6 @@ func getMigrations() -> DatabaseMigrator {
             t.column("name", .text).notNull()
         }
 
-        // TODO Add method to automatically add episodes based on torrent item
         try db.create(table: "episodes", ifNotExists: true) { t in
             t.autoIncrementedPrimaryKey("id")
             t.column("seriesId", .integer)
@@ -51,6 +50,11 @@ func getMigrations() -> DatabaseMigrator {
             t.column("status", .text).notNull()
             t.column("date", .datetime).notNull()
         }
+    }
+
+    migrator.registerMigration("v2") { db in
+        try db.rename(table: "episodes", to: "episode")
+
     }
 
     return migrator;

--- a/Sources/TorrentRSS/TorrentRSS.swift
+++ b/Sources/TorrentRSS/TorrentRSS.swift
@@ -79,6 +79,10 @@ public struct TorrentRSS {
         try store.initializeSeries()
     }
 
+    public func initializeEpisodes() throws {
+        try store.initializeEpisodes()
+    }
+
     public func updatePendingDownload() throws {
 
         print("[INFO] [\(Date())] Starting Transmission Update")

--- a/Sources/trss/main.swift
+++ b/Sources/trss/main.swift
@@ -35,5 +35,6 @@ if args.count != 3 {
     let torrentRSSFeed = TorrentRSS(serverOptions!, feedOptions!)
     try torrentRSSFeed.fetchAndUpdateDB()
     try torrentRSSFeed.initializeSeries()
+    try torrentRSSFeed.initializeEpisodes()
     try torrentRSSFeed.updatePendingDownload()
 }


### PR DESCRIPTION
There is already a function that parses the title and gets both the series name and the episode number. Just need to add it to the pipeline, ideally with some testing.